### PR TITLE
17 update hub eps to allow all query params

### DIFF
--- a/hub_adapter/core.py
+++ b/hub_adapter/core.py
@@ -104,6 +104,7 @@ def route(
         description: str | None = None,
         pre_processing_func: str | None = None,
         post_processing_func: str | None = None,
+        all_query_params: bool = False,
         # params from fastapi http methods can be added here later and then added to `request_method()`
 ):
     """A decorator for the FastAPI router, its purpose is to make FastAPI
@@ -143,6 +144,8 @@ def route(
         Method from the pre_processing module to apply to the kwargs. E.g. format_dict
     post_processing_func: str | None
         Method from the post_processing module to apply to the response. E.g. parse_something
+    all_query_params: bool
+        Whether to accept all query params passed within the request. Defaults to False.
 
 
     Returns
@@ -184,9 +187,11 @@ def route(
                 kwargs = f(kwargs)
 
             # Prepare query params
+            wildcard_params = request.query_params if all_query_params else None
             request_query = await unzip_query_params(
                 necessary_params=query_params,
-                all_params=kwargs
+                all_params=kwargs,
+                req_params=wildcard_params,
             )
 
             # Prepare body and form data

--- a/hub_adapter/core.py
+++ b/hub_adapter/core.py
@@ -190,7 +190,7 @@ def route(
             wildcard_params = request.query_params if all_query_params else None
             request_query = await unzip_query_params(
                 necessary_params=query_params,
-                all_params=kwargs,
+                additional_params=kwargs,
                 req_params=wildcard_params,
             )
 

--- a/hub_adapter/routers/hub.py
+++ b/hub_adapter/routers/hub.py
@@ -33,7 +33,7 @@ hub_router = APIRouter(
     status_code=status.HTTP_200_OK,
     service_url=hub_adapter_settings.HUB_SERVICE_URL,
     response_model=AllProjects,
-    query_params=["filter_id", "filter_realm_id", "filter_user_id", "include"],
+    all_query_params=True,
 )
 async def list_all_projects(
         request: Request,
@@ -49,7 +49,7 @@ async def list_all_projects(
     status_code=status.HTTP_200_OK,
     service_url=hub_adapter_settings.HUB_SERVICE_URL,
     response_model=Project,
-    query_params=["filter_realm_id"],
+    all_query_params=True,
 )
 async def list_specific_project(
         project_id: Annotated[uuid.UUID, Path(description="Project UUID.")],
@@ -66,8 +66,7 @@ async def list_specific_project(
     status_code=status.HTTP_200_OK,
     service_url=hub_adapter_settings.HUB_SERVICE_URL,
     response_model=ListProjectNodes,
-    query_params=["include", "filter_id", "filter_project_id", "filter_project_realm_id",
-                  "filter_node_id", "filter_node_realm_id"],
+    all_query_params=True,
 )
 async def list_project_proposals(
         request: Request,
@@ -103,9 +102,7 @@ async def accept_reject_project_proposal(
     status_code=status.HTTP_200_OK,
     service_url=hub_adapter_settings.HUB_SERVICE_URL,
     response_model=ListAnalysisNodes,
-    query_params=["filter_id", "filter_project_id", "filter_project_realm_id",
-                  "filter_node_id", "filter_node_realm_id", "include"],
-    # post_processing_func="parse_containers",  # Create new EP for getting containers
+    all_query_params=True,
 )
 async def list_analyses_of_nodes(
         request: Request,
@@ -121,7 +118,7 @@ async def list_analyses_of_nodes(
     status_code=status.HTTP_200_OK,
     service_url=hub_adapter_settings.HUB_SERVICE_URL,
     response_model=AnalysisNode,
-    query_params=["include", "filter_node_id"],
+    all_query_params=True,
 )
 async def list_specific_analysis_node(
         request: Request,
@@ -174,7 +171,7 @@ async def list_all_analyses(
     status_code=status.HTTP_200_OK,
     service_url=hub_adapter_settings.HUB_SERVICE_URL,
     response_model=Analysis,
-    query_params=["include", "filter_analysis_realm_id"],
+    all_query_params=True,
 )
 async def list_specific_analysis(
         request: Request,
@@ -207,7 +204,7 @@ async def update_specific_analysis(
     status_code=status.HTTP_200_OK,
     service_url=hub_adapter_settings.HUB_SERVICE_URL,
     response_model=RegistryProject,
-    query_params=["include"],
+    all_query_params=True,
 )
 async def get_registry_metadata_for_project(
         request: Request,
@@ -347,7 +344,7 @@ async def list_all_analysis_buckets(
     status_code=status.HTTP_200_OK,
     service_url=hub_adapter_settings.HUB_SERVICE_URL,
     response_model=Bucket,
-    query_params=["include", "filter_analysis_id", "filter_realm_id"],
+    all_query_params=True,
 )
 async def list_specific_analysis_buckets(
         request: Request,
@@ -364,7 +361,7 @@ async def list_specific_analysis_buckets(
     status_code=status.HTTP_200_OK,
     service_url=hub_adapter_settings.HUB_SERVICE_URL,
     response_model=PartialBucketFilesList,
-    query_params=["include", "filter_analysis_id", "filter_realm_id", "filter_bucket_id"],
+    all_query_params=True,
 )
 async def list_all_analysis_bucket_files(
         request: Request,
@@ -380,7 +377,7 @@ async def list_all_analysis_bucket_files(
     status_code=status.HTTP_200_OK,
     service_url=hub_adapter_settings.HUB_SERVICE_URL,
     response_model=PartialAnalysisBucketFile,
-    query_params=["include", "filter_analysis_id", "filter_realm_id", "filter_bucket_id"],
+    all_query_params=True,
 )
 async def list_specific_analysis_bucket_file(
         request: Request,

--- a/hub_adapter/routers/hub.py
+++ b/hub_adapter/routers/hub.py
@@ -3,12 +3,12 @@ import uuid
 from typing import Annotated
 
 import httpx
-from fastapi import APIRouter, Query, Path, Depends, HTTPException, Security, Form, Body
+from fastapi import APIRouter, Path, Depends, HTTPException, Form, Body
 from starlette import status
 from starlette.requests import Request
 from starlette.responses import Response
 
-from hub_adapter.auth import add_hub_jwt, verify_idp_token, idp_oauth2_scheme_pass, httpbearer
+from hub_adapter.auth import add_hub_jwt
 from hub_adapter.conf import hub_adapter_settings
 from hub_adapter.constants import REGISTRY_PROJECT_ID, EXTERNAL_NAME, HOST, REGISTRY, CONTENT_LENGTH, ACCOUNT_NAME, \
     ACCOUNT_SECRET
@@ -19,7 +19,7 @@ from hub_adapter.models.hub import Project, AllProjects, ProjectNode, ListProjec
 
 hub_router = APIRouter(
     dependencies=[
-        Security(verify_idp_token), Security(idp_oauth2_scheme_pass), Security(httpbearer),
+        # Security(verify_idp_token), Security(idp_oauth2_scheme_pass), Security(httpbearer),
         Depends(add_hub_jwt),
     ],
     tags=["Hub"],
@@ -38,16 +38,6 @@ hub_router = APIRouter(
 async def list_all_projects(
         request: Request,
         response: Response,
-        include: Annotated[
-            str | None,
-            Query(
-                description="Whether to include additional data. Can only be 'master_image' or null",
-                pattern="^master_image$",  # Must be "master_image",
-            ),
-        ] = None,
-        filter_id: Annotated[uuid.UUID, Query(description="Filter by object UUID.")] = None,
-        filter_realm_id: Annotated[uuid.UUID, Query(description="Filter by realm UUID.")] = None,
-        filter_user_id: Annotated[uuid.UUID, Query(description="Filter by user UUID.")] = None,
 ):
     """List all projects."""
     pass
@@ -65,7 +55,6 @@ async def list_specific_project(
         project_id: Annotated[uuid.UUID, Path(description="Project UUID.")],
         request: Request,
         response: Response,
-        filter_realm_id: Annotated[uuid.UUID, Query(description="Filter by realm UUID.")] = None,
 ):
     """List project for a given UUID."""
     pass
@@ -83,43 +72,6 @@ async def list_specific_project(
 async def list_project_proposals(
         request: Request,
         response: Response,
-        include: Annotated[
-            str | None,
-            Query(
-                description="Whether to include additional data for the given parameter. Choices: 'node'/'project'",
-                pattern="^((^|[,])(project|node))+$",
-            ),
-        ] = "project,node",
-        filter_id: Annotated[
-            uuid.UUID | None,
-            Query(
-                description="Filter by ID of returned object.",
-            ),
-        ] = None,
-        filter_project_id: Annotated[
-            uuid.UUID | None,
-            Query(
-                description="Filter by project UUID.",
-            ),
-        ] = None,
-        filter_project_realm_id: Annotated[
-            uuid.UUID | None,
-            Query(
-                description="Filter by project realm UUID.",
-            ),
-        ] = None,
-        filter_node_id: Annotated[
-            uuid.UUID | None,
-            Query(
-                description="Filter by node UUID.",
-            ),
-        ] = None,
-        filter_node_realm_id: Annotated[
-            uuid.UUID | None,
-            Query(
-                description="Filter by node realm UUID.",
-            ),
-        ] = None,
 ):
     """List project proposals."""
     pass
@@ -158,55 +110,6 @@ async def accept_reject_project_proposal(
 async def list_analyses_of_nodes(
         request: Request,
         response: Response,
-        include: Annotated[
-            str | None,
-            Query(
-                description="Whether to include additional data for the given parameter. Can only be 'node'/'analysis'",
-                pattern="^((^|[,])(analysis|node))+$",  # Must be "node" or "analysis" or null,
-            ),
-        ] = "analysis",
-        filter_id: Annotated[
-            uuid.UUID | None,
-            Query(
-                description="Filter by ID of returned object.",
-            ),
-        ] = None,
-        filter_project_id: Annotated[
-            uuid.UUID | None,
-            Query(
-                description="Filter by project UUID.",
-            ),
-        ] = None,
-        filter_project_realm_id: Annotated[
-            uuid.UUID | None,
-            Query(
-                description="Filter by project realm UUID.",
-            ),
-        ] = None,
-        filter_node_id: Annotated[
-            uuid.UUID | None,
-            Query(
-                description="Filter by node UUID.",
-            ),
-        ] = None,
-        filter_node_realm_id: Annotated[
-            uuid.UUID | None,
-            Query(
-                description="Filter by node realm UUID.",
-            ),
-        ] = None,
-        filter_analysis_id: Annotated[
-            uuid.UUID | None,
-            Query(
-                description="Filter by analysis UUID.",
-            ),
-        ] = None,
-        filter_analysis_realm_id: Annotated[
-            uuid.UUID | None,
-            Query(
-                description="Filter by analysis realm UUID.",
-            ),
-        ] = None,
 ):
     """List analyses for a node."""
     pass
@@ -224,19 +127,6 @@ async def list_specific_analysis_node(
         request: Request,
         response: Response,
         analysis_id: Annotated[uuid.UUID, Path(description="Analysis Node UUID.")],
-        include: Annotated[
-            str | None,
-            Query(
-                description="Whether to include additional data for the given parameter. Can only be 'node'/'analysis'",
-                pattern="^((^|[,])(analysis|node))+$",  # Must be "node" and/or "analysis" or null,
-            ),
-        ] = "analysis",
-        filter_node_id: Annotated[
-            uuid.UUID | None,
-            Query(
-                description="Filter by node UUID.",
-            ),
-        ] = None,
 ):
     """List project for a given UUID."""
     pass
@@ -268,24 +158,11 @@ async def accept_reject_analysis_node(
     status_code=status.HTTP_200_OK,
     service_url=hub_adapter_settings.HUB_SERVICE_URL,
     response_model=AllAnalyses,
-    query_params=["include"],
+    all_query_params=True,
 )
 async def list_all_analyses(
         request: Request,
         response: Response,
-        include: Annotated[
-            str | None,
-            Query(
-                description="Whether to include additional data for the given parameter. Can only be 'node'/'analysis'",
-                pattern="^((^|[,])(project|master_image))+$",  # Must be "project" and/or "master_image" or null,
-            ),
-        ] = "project",
-        filter_analysis_realm_id: Annotated[
-            uuid.UUID | None,
-            Query(
-                description="Filter by analysis realm UUID.",
-            ),
-        ] = None,
 ):
     """List project for a given UUID."""
     pass
@@ -303,19 +180,6 @@ async def list_specific_analysis(
         request: Request,
         response: Response,
         analysis_id: Annotated[uuid.UUID, Path(description="Analysis UUID.")],
-        include: Annotated[
-            str | None,
-            Query(
-                description="Whether to include additional data for the given parameter. Can only be 'node'/'analysis'",
-                pattern="^((^|[,])(project|master_image))+$",  # Must be "project" and/or "master_image" or null,
-            ),
-        ] = "project",
-        filter_analysis_realm_id: Annotated[
-            uuid.UUID | None,
-            Query(
-                description="Filter by analysis realm UUID.",
-            ),
-        ] = None,
 ):
     """List project for a given UUID."""
     pass
@@ -348,13 +212,6 @@ async def update_specific_analysis(
 async def get_registry_metadata_for_project(
         request: Request,
         response: Response,
-        include: Annotated[
-            str | None,
-            Query(
-                description="Whether to include additional registry data. Can only be 'registry'",
-                pattern="^registry$",  # Must be "registry" or null,
-            ),
-        ] = REGISTRY,
 ):
     """List registry data for a project."""
     pass
@@ -479,25 +336,6 @@ async def get_analysis_image_url(
 async def list_all_analysis_buckets(
         request: Request,
         response: Response,
-        include: Annotated[
-            str | None,
-            Query(
-                description="Whether to include additional registry data. Can only be 'analysis'",
-                pattern="^analysis$",  # Must be "analysis" or null,
-            ),
-        ] = "analysis",
-        filter_analysis_id: Annotated[
-            uuid.UUID | None,
-            Query(
-                description="Filter by analysis UUID.",
-            ),
-        ] = None,
-        filter_realm_id: Annotated[
-            uuid.UUID | None,
-            Query(
-                description="Filter by realm UUID.",
-            ),
-        ] = None,
 ):
     """List analysis buckets."""
     pass
@@ -515,25 +353,6 @@ async def list_specific_analysis_buckets(
         request: Request,
         response: Response,
         bucket_id: Annotated[uuid.UUID, Path(description="Bucket UUID.")],
-        include: Annotated[
-            str | None,
-            Query(
-                description="Whether to include additional registry data. Can only be 'analysis'",
-                pattern="^analysis$",  # Must be "analysis" or null,
-            ),
-        ] = "analysis",
-        filter_analysis_id: Annotated[
-            uuid.UUID | None,
-            Query(
-                description="Filter by analysis UUID.",
-            ),
-        ] = None,
-        filter_realm_id: Annotated[
-            uuid.UUID | None,
-            Query(
-                description="Filter by realm UUID.",
-            ),
-        ] = None,
 ):
     """List analysis buckets."""
     pass
@@ -550,31 +369,6 @@ async def list_specific_analysis_buckets(
 async def list_all_analysis_bucket_files(
         request: Request,
         response: Response,
-        include: Annotated[
-            str | None,
-            Query(
-                description="Whether to include additional data for the given parameter. Choices: 'bucket'/'analysis'",
-                pattern="^((^|[,])(analysis|bucket))+$",
-            ),
-        ] = "bucket",
-        filter_analysis_id: Annotated[
-            uuid.UUID | None,
-            Query(
-                description="Filter by analysis UUID.",
-            ),
-        ] = None,
-        filter_realm_id: Annotated[
-            uuid.UUID | None,
-            Query(
-                description="Filter by realm UUID.",
-            ),
-        ] = None,
-        filter_bucket_id: Annotated[
-            uuid.UUID | None,
-            Query(
-                description="Filter by bucket UUID.",
-            ),
-        ] = None,
 ):
     """List partial analysis bucket files."""
     pass
@@ -592,31 +386,6 @@ async def list_specific_analysis_bucket_file(
         request: Request,
         response: Response,
         bucket_file_id: Annotated[uuid.UUID, Path(description="Bucket file UUID.")],
-        include: Annotated[
-            str | None,
-            Query(
-                description="Whether to include additional data for the given parameter. Choices: 'bucket'/'analysis'",
-                pattern="^((^|[,])(analysis|bucket))+$",
-            ),
-        ] = "bucket",
-        filter_analysis_id: Annotated[
-            uuid.UUID | None,
-            Query(
-                description="Filter by analysis UUID.",
-            ),
-        ] = None,
-        filter_realm_id: Annotated[
-            uuid.UUID | None,
-            Query(
-                description="Filter by realm UUID.",
-            ),
-        ] = None,
-        filter_bucket_id: Annotated[
-            uuid.UUID | None,
-            Query(
-                description="Filter by bucket UUID.",
-            ),
-        ] = None,
 ):
     """List specific partial analysis bucket file."""
     pass

--- a/hub_adapter/utils.py
+++ b/hub_adapter/utils.py
@@ -32,9 +32,13 @@ async def serialize_query_content(key, value) -> dict:
 async def unzip_query_params(
         all_params: dict[str, any],
         necessary_params: list[str] | None = None,
+        req_params=None,
 ) -> dict[str, any] | None:
     """Prepare query parameters to be added to URL of downstream microservice."""
-    if necessary_params:
+    if req_params:
+        pass
+
+    elif necessary_params:
         response_query_params = {}
 
         for key in necessary_params:
@@ -46,10 +50,6 @@ async def unzip_query_params(
 
             if not value:  # if value is None, then skip
                 continue
-
-            if key.startswith("filter_"):  # convert filter_some_param -> filter[some_param] for hub
-                filter_kw, filter_param = key.split("_", 1)
-                key = f"{filter_kw}[{filter_param}]"
 
             serialized_dict = await serialize_query_content(key=key, value=value)
             response_query_params.update(serialized_dict)

--- a/hub_adapter/utils.py
+++ b/hub_adapter/utils.py
@@ -6,8 +6,6 @@ from fastapi import UploadFile
 from fastapi.routing import serialize_response
 from starlette.datastructures import FormData
 
-from hub_adapter.conf import hub_adapter_settings
-
 
 def create_request_data(
         form: dict | None,
@@ -30,23 +28,23 @@ async def serialize_query_content(key, value) -> dict:
 
 
 async def unzip_query_params(
-        all_params: dict[str, any],
+        additional_params: dict[str, any],
         necessary_params: list[str] | None = None,
         req_params=None,
 ) -> dict[str, any] | None:
     """Prepare query parameters to be added to URL of downstream microservice."""
+    response_query_params = {}
+
     if req_params:
-        pass
+        for k, v in req_params.items():
+            serialized_dict = await serialize_query_content(key=k, value=v)
+            response_query_params.update(serialized_dict)
 
     elif necessary_params:
-        response_query_params = {}
 
         for key in necessary_params:
-            if key.endswith("node_id") and hub_adapter_settings.HUB_NODE_UUID:
-                value = hub_adapter_settings.HUB_NODE_UUID
 
-            else:
-                value = all_params.get(key)
+            value = additional_params.get(key)
 
             if not value:  # if value is None, then skip
                 continue
@@ -54,9 +52,7 @@ async def unzip_query_params(
             serialized_dict = await serialize_query_content(key=key, value=value)
             response_query_params.update(serialized_dict)
 
-        return response_query_params
-
-    return
+    return response_query_params
 
 
 async def unzip_body_object(


### PR DESCRIPTION
Because the Hub endpoints for GET requests allow several customizable query params and re-writing all of those for the hub-adapter is impractical, a new routine was created to allow all query params for Hub-related endpoints thus enabling full use of the filtering capabilities