### PR TITLE
Enable use of forward proxies

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,5 +37,7 @@ HUB_ROBOT_SECRET="hubpassword"  # These will be removed later once users are reg
 API_CLIENT_ID="hub-adapter"  # Client name of this API as defined in keycloak
 API_CLIENT_SECRET="someSecret"  # Client secret of this API as defined in keycloak
 #NODE_SVC_OIDC_URL="https://data-center.node.com/keycloak/realms/flame"  # The internal IDP used by other Node microsvcs
-#OVERRIDE_JWKS=""  # JWKS URI to override the endpoints fetched from the IDP issuer (meant for local testing)  
+OVERRIDE_JWKS=""  # JWKS URI to override the endpoints fetched from the IDP issuer (meant for local testing)
+HA_HTTP_PROXY=""  # Forward proxy address for HTTP requests
+HA_HTTPS_PROXY=""  # Forward proxy address for HTTPS requests
 ```

--- a/hub_adapter/__init__.py
+++ b/hub_adapter/__init__.py
@@ -42,7 +42,7 @@ logging_config = {
             "maxBytes": 4098 * 10,  # 4MB file max
             "backupCount": 5,
             "formatter": "file_formatter",
-            "level": "DEBUG",
+            "level": "INFO",
         },
         "console_handler": {
             "class": "logging.StreamHandler",
@@ -52,15 +52,11 @@ logging_config = {
         },
     },
     "root": {
-        "level": "DEBUG",
+        "level": "INFO",
         "handlers": ["file_handler", "console_handler"],
     },
     "loggers": {
-        "httpx": {
-            "handlers": ["console_handler", "file_handler"],
-            "level": "INFO",
-        },
-        "httpcore": {
+        "flame_hub": {
             "handlers": ["console_handler", "file_handler"],
             "level": "INFO",
         },

--- a/hub_adapter/auth.py
+++ b/hub_adapter/auth.py
@@ -47,13 +47,13 @@ def fetch_openid_config(oidc_url: str, max_retries: int = 6) -> OIDCConfiguratio
         except (httpx.ConnectError, httpx.ReadTimeout):  # OIDC Service not up yet
             attempt_num += 1
             wait_time = 10 * (2 ** (attempt_num - 1))  # 10s, 20s, 40s, 80s, 160s, 320s
-            logger.warning(
-                f"Unable to contact the IDP at {oidc_url}, retrying in {wait_time} seconds"
-            )
+            logger.warning(f"Unable to contact the IDP at {oidc_url}, retrying in {wait_time} seconds")
             time.sleep(wait_time)
 
         except httpx.HTTPStatusError as e:
-            err_msg = f"HTTP error occurred while trying to contact the IDP: {provided_url}, is this the correct issuer URL?"
+            err_msg = (
+                f"HTTP error occurred while trying to contact the IDP: {provided_url}, is this the correct issuer URL?"
+            )
             logger.error(err_msg + f" - {e}")
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
@@ -65,9 +65,7 @@ def fetch_openid_config(oidc_url: str, max_retries: int = 6) -> OIDCConfiguratio
             ) from e
 
     logger.error(f"Unable to contact the IDP at {oidc_url} after {max_retries} retries")
-    raise httpx.ConnectError(
-        f"Unable to contact the IDP at {oidc_url} after {max_retries} retries"
-    )
+    raise httpx.ConnectError(f"Unable to contact the IDP at {oidc_url} after {max_retries} retries")
 
 
 def get_user_oidc_config() -> OIDCConfiguration:
@@ -110,9 +108,7 @@ async def verify_idp_token(
 
     try:
         # Decode just to get issuer
-        unverified_claims = jwt.decode(
-            token.credentials, options={"verify_signature": False}
-        )
+        unverified_claims = jwt.decode(token.credentials, options={"verify_signature": False})
         issuer = unverified_claims.get("iss")
 
         if hub_adapter_settings.OVERRIDE_JWKS:  # Override the fetched URIs
@@ -190,9 +186,7 @@ def get_hub_token() -> RobotAuth:
 
     if not robot_id or not robot_secret:
         logger.error("Missing robot ID or secret. Check env vars")
-        raise ValueError(
-            "Missing Hub robot credentials, check that the environment variables are set properly"
-        )
+        raise ValueError("Missing Hub robot credentials, check that the environment variables are set properly")
 
     try:
         uuid.UUID(robot_id)
@@ -204,10 +198,16 @@ def get_hub_token() -> RobotAuth:
     auth = RobotAuth(
         robot_id=robot_id,
         robot_secret=robot_secret,
-        base_url=hub_adapter_settings.HUB_AUTH_SERVICE_URL,
+        client=httpx.Client(
+            base_url=hub_adapter_settings.HUB_AUTH_SERVICE_URL, mounts=hub_adapter_settings.PROXY_MOUNTS
+        ),
     )
     return auth
 
 
 hub_robot = get_hub_token()
-core_client = CoreClient(auth=hub_robot, base_url=hub_adapter_settings.HUB_SERVICE_URL)
+core_client = CoreClient(
+    client=httpx.Client(
+        base_url=hub_adapter_settings.HUB_SERVICE_URL, mounts=hub_adapter_settings.PROXY_MOUNTS, auth=hub_robot
+    ),
+)

--- a/hub_adapter/conf.py
+++ b/hub_adapter/conf.py
@@ -2,6 +2,7 @@
 
 import os
 
+import httpx
 from pydantic import BaseModel
 
 
@@ -10,6 +11,11 @@ class Settings(BaseModel):
     """Settings for Hub Adapter API."""
 
     API_ROOT_PATH: str = os.getenv("API_ROOT_PATH", "")
+
+    # Proxies
+    HTTP_PROXY: str = os.getenv("HA_HTTP_PROXY")
+    HTTPS_PROXY: str = os.getenv("HA_HTTPS_PROXY")
+    PROXY_MOUNTS: dict | None = None
 
     # IDP Settings
     IDP_URL: str = os.getenv("IDP_URL", "http://localhost:8080")  # User
@@ -35,3 +41,9 @@ class Settings(BaseModel):
 
 
 hub_adapter_settings = Settings()
+
+if hub_adapter_settings.HTTP_PROXY or hub_adapter_settings.HTTPS_PROXY:
+    hub_adapter_settings.PROXY_MOUNTS = {
+        "http://": httpx.HTTPTransport(proxy=hub_adapter_settings.HTTP_PROXY or hub_adapter_settings.HTTPS_PROXY),
+        "https://": httpx.HTTPTransport(proxy=hub_adapter_settings.HTTPS_PROXY or hub_adapter_settings.HTTP_PROXY),
+    }

--- a/hub_adapter/core.py
+++ b/hub_adapter/core.py
@@ -68,7 +68,7 @@ async def make_request(
     if not files:
         files = {}
 
-    async with httpx.AsyncClient(headers=headers, timeout=60.0) as client:
+    async with httpx.AsyncClient(headers=headers, timeout=60.0, mounts=None) as client:
         r = await client.request(
             url=url,
             method=method,

--- a/hub_adapter/errors.py
+++ b/hub_adapter/errors.py
@@ -22,6 +22,19 @@ def catch_hub_errors(f):
         try:
             return await f(*args, **kwargs)
 
+        except httpx.ProxyError:
+            err = "Proxy Error - Unable to contact the Hub"
+            logger.error(err)
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail={
+                    "message": err,
+                    "service": "proxy",
+                    "status_code": status.HTTP_400_BAD_REQUEST,
+                },
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+
         except HubAPIError as err:
             resp_error = err.error_response
 

--- a/hub_adapter/server.py
+++ b/hub_adapter/server.py
@@ -65,4 +65,4 @@ for router in routers:
 
 
 if __name__ == "__main__":
-    uvicorn.run("server:app", host="127.0.0.1", port=8081, reload=False)
+    uvicorn.run("server:app", host="127.0.0.1", port=8081, reload=False, log_config=None)


### PR DESCRIPTION
Hub Adapter now properly parses 2 new env vars: `HA_HTTP_PROXY` & `HA_HTTPS_PROXY` which are used to configure the `flame_hub` library and `PyJWT` so that the hub can be contacted and IDP tokens parsed, respectively, when behind a forward proxy