### PR TITLE
Add edge and canary ci steps

### DIFF
--- a/.github/actions/build-docker-image/action.yaml
+++ b/.github/actions/build-docker-image/action.yaml
@@ -36,6 +36,8 @@ runs:
   steps:
     - name: Checkout
       uses: actions/checkout@v6
+      with:
+        persist-credentials: false
 
     - name: Set up QEMU
       uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf  # tag=v3.2.0

--- a/.github/actions/build-docker-image/action.yaml
+++ b/.github/actions/build-docker-image/action.yaml
@@ -25,6 +25,10 @@ inputs:
     default: ""
     description: "Suffix to append to the image tags"
     required: false
+  extra_tag:
+    default: ""
+    description: "An extra raw tag to apply to the image (e.g. edge, canary)"
+    required: false
 
 runs:
   using: composite
@@ -65,6 +69,7 @@ runs:
           type=raw,value=canary,enable=${{ github.event_name == 'workflow_dispatch' }}
           type=raw,event=workflow_dispatch,value=${{ github.event.inputs.dispatch-tag }}
           type=semver,pattern={{version}},value=${{ inputs.image_tags }},branch=main
+          type=raw,value=${{ inputs.extra_tag }},enable=${{ inputs.extra_tag != '' }}
 
     - name: Clean variables
       id: clean

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,6 +22,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@v6
         with:
@@ -42,6 +44,8 @@ jobs:
     steps:
       - name: Checkout  # required for finding action
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - uses: ./.github/actions/build-docker-image
         with:

--- a/.github/workflows/docker-preview.yaml
+++ b/.github/workflows/docker-preview.yaml
@@ -7,7 +7,7 @@ on:
   pull_request:
     branches:
       - main
-    types: [opened, synchronize, reopened]
+    types: [ opened, synchronize, reopened ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Build edge image
         uses: ./.github/actions/build-docker-image
@@ -44,6 +46,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Build canary image
         uses: ./.github/actions/build-docker-image

--- a/.github/workflows/docker-preview.yaml
+++ b/.github/workflows/docker-preview.yaml
@@ -1,0 +1,55 @@
+name: Docker Preview Images
+
+on:
+  push:
+    branches-ignore:
+      - main
+  pull_request:
+    branches:
+      - main
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-edge-image:
+    name: Build and push edge Docker image
+    if: ${{ github.event_name == 'push' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Build edge image
+        uses: ./.github/actions/build-docker-image
+        with:
+          platforms: linux/amd64
+          docker_file: Dockerfile
+          push: 'true'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          extra_tag: edge
+
+  build-canary-image:
+    name: Build and push canary Docker image
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Build canary image
+        uses: ./.github/actions/build-docker-image
+        with:
+          platforms: linux/amd64
+          docker_file: Dockerfile
+          push: 'true'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          extra_tag: canary

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,6 +39,8 @@ jobs:
     steps:
       - name: Checkout  # required for finding action
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Build production image
         uses: ./.github/actions/build-docker-image
@@ -59,6 +61,8 @@ jobs:
     steps:
       - name: Checkout  # required for finding action
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Build canary image
         uses: ./.github/actions/build-docker-image


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added preview Docker image tags for non-main updates, including separate **edge** and **canary** builds.
  * Docker image builds now support an optional extra tag, making it easier to publish alternate image labels.

* **Chores**
  * Improved CI behavior so preview image builds run automatically for the appropriate push and pull request events, with overlapping runs canceled to save time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->